### PR TITLE
Fixed: spec/system/task_spec.rbのFactoryBotに関する記述を修正

### DIFF
--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,13 +13,34 @@ RSpec.describe Task, type: :system do
 
   describe 'タスク登録画面' do
     context '必要項目を入力して、createボタンを押した場合' do
-      it 'データが保存されること'
+      it 'データが保存されること' do
+        visit new_task_path
+        fill_in 'Title', with: 'TEST_TITLE' #
+        fill_in 'Content', with: 'TEST_CONTENT'
+        click_on 'Create Task' #
+        expect(page).to have_content 'TEST_TITLE'
+        # <%= form.label :title %>が生成した
+        # <label for="task_title">Title</label>の
+        # 'Title'にwith: 'TEST_TITLE'をfill_in
+
+        # <%= form.submit %>が生成した
+        # <input type="submit" name="commit" value="Create Task" data-disable-with="Create Task">に
+        # click_on 'Create Task'
+
+        end
+      end
     end
-  end
 
   describe 'タスク詳細画面' do
      context '任意のタスク詳細画面に遷移した場合' do
-       it '該当タスクの内容が表示されたページに遷移すること'
+       it '該当タスクの内容が表示されたページに遷移すること' do
+
+
+       visit tasks_path
+       first(:link, 'Show').click
+       expect(page).to have_content 'TITLE1'
+       end
+
      end
   end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,10 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :system do
+  before do
+    @task = FactoryBot.create(:task)
+  end
   describe 'タスク一覧画面' do
     context 'タスクを作成した場合' do
       it '作成済みのタスクが表示されること' do
-      @task = FactoryBot.create(:task)
+
       visit tasks_path
       expect(page).to have_content 'TEST_TITLE'
       end
@@ -38,7 +41,7 @@ RSpec.describe Task, type: :system do
 
        visit tasks_path
        first(:link, 'Show').click
-       expect(page).to have_content 'TITLE1'
+       expect(page).to have_content 'TITLE3'
        end
 
      end


### PR DESCRIPTION
fixes #19 

- [ ] 「タスク登録画面で、必要項目を入力してcreateボタンを押したらデータが保存される」ことのテストを成功させましょう。
- [ ] 「任意のタスク詳細画面に遷移したら、該当タスクの内容が表示されたページに遷移する」ことのテストを成功させましょう。